### PR TITLE
Update Scala version to 3.3.4 (LTS)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.scala-lang', name: 'scala-compiler', version: '2.12.18'
+    implementation group: 'org.scala-lang', name: 'scala3-compiler_3', version: '3.3.4'
 }
 
 // Need to compile scala and java jointly so Java class can call ScalaHelper

--- a/ghidra_scripts/FuncParams.scala
+++ b/ghidra_scripts/FuncParams.scala
@@ -8,15 +8,14 @@ import ghidra.app.script.GhidraScript
 
 import ghidra.program.model.pcode._
 
-class FuncParams extends GhidraScript {
+class FuncParams extends GhidraScript:
 
-  override def run() = {
+  override def run() =
     println("Hello world, I'm written in Scala...!")
 
     val ifc = new DecompInterface
-    if (!ifc.openProgram(currentProgram)) {
+    if !ifc.openProgram(currentProgram) then
       throw new DecompileException("Decompiler", "Unable to initialize: " + ifc.getLastMessage)
-    }
 
     val res = ifc.decompileFunction(currentProgram.getFunctionManager.getFunctionContaining(currentAddress), 60, null)
     val hf = res.getHighFunction
@@ -27,5 +26,3 @@ class FuncParams extends GhidraScript {
       .map(_.getStorage.toString).mkString(", ")
 
     println(s"Function ${hf.getFunction.getName}: ${storage}")
-  }
-}

--- a/ghidra_scripts/HelloWorldScript.scala
+++ b/ghidra_scripts/HelloWorldScript.scala
@@ -5,7 +5,6 @@
 
 import ghidra.app.script.GhidraScript
 
-class HelloWorldScript extends GhidraScript {
+class HelloWorldScript extends GhidraScript:
 
-  override def run() = println("Hello world, I'm written in Scala!")
-}
+  override def run() = println("Hello world, I'm written in Scala 3!")

--- a/ghidra_scripts/InstructionOps.scala
+++ b/ghidra_scripts/InstructionOps.scala
@@ -7,12 +7,11 @@ import ghidra.program.model.listing.Function
 import ghidra.program.model.address.AddressSetView
 import ghidra.program.model.symbol.Reference
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters.*
 
-class InstructionOps extends GhidraScript {
+class InstructionOps extends GhidraScript:
 
-  override def run() = {
-
+  override def run() =
 
     println("Starting InstructionOps script")
     
@@ -23,12 +22,12 @@ class InstructionOps extends GhidraScript {
 
     val l = getCurrentProgram.getListing
 
-    funcs.foreach(f => {
+    funcs.foreach(f =>
       println(s"Function ${f.getName}")
-      l.getInstructions(f.getBody, true).forEach(i => {
+      l.getInstructions(f.getBody, true).forEach(i =>
         val numops = i.getNumOperands
         println(s" Insn: ${i} has ${numops} operands")
-        (0 to numops-1).foreach(opnum => {
+        (0 to numops-1).foreach(opnum =>
           println(s"  Operand ${opnum} ${i.getDefaultOperandRepresentation(opnum)}")
           //println(s"  Operand ${opnum} is ${i.getOpObjects(opnum)}")
           val reftype = i.getOperandRefType(opnum)
@@ -36,8 +35,6 @@ class InstructionOps extends GhidraScript {
           val optype = i.getOperandType(opnum)
           val optypestr = ghidra.program.model.lang.OperandType.toString(optype)
           println(s"  Operand ${opnum} op type ${optypestr}")
-        })
-      })
-    })
-  }
-}
+        )
+      )
+    )

--- a/ghidra_scripts/PopularFunctions.scala
+++ b/ghidra_scripts/PopularFunctions.scala
@@ -7,11 +7,11 @@ import ghidra.program.model.listing.Function
 import ghidra.program.model.address.AddressSetView
 import ghidra.program.model.symbol.Reference
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters.*
 
-class PopularFunctions extends GhidraScript {
+class PopularFunctions extends GhidraScript:
 
-  override def run() = {
+  override def run() =
     val p = getCurrentProgram
     val refmgr = p.getReferenceManager
     getCurrentProgram.getFunctionManager
@@ -30,5 +30,3 @@ class PopularFunctions extends GhidraScript {
       .sortWith(_._2 > _._2)
       .take(20)
       .foreach{case (f,cnt) => println(s"Function ${f.getName} (${f.getEntryPoint}) is referenced $cnt times")}
-  }
-}

--- a/ghidra_scripts/PrintHighPCode.scala
+++ b/ghidra_scripts/PrintHighPCode.scala
@@ -4,15 +4,14 @@
 
 import ghidra.app.script.GhidraScript
 import ghidra.app.decompiler._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters.*
 
-class PrintHighPCode extends GhidraScript {
+class PrintHighPCode extends GhidraScript:
 
-  override def run() = {
+  override def run() =
     val ifc = new DecompInterface
-    if (!ifc.openProgram(currentProgram)) {
+    if !ifc.openProgram(currentProgram) then
       throw new DecompileException("Decompiler", "Unable to initialize: " + ifc.getLastMessage)
-    }
 
     ifc.setSimplificationStyle("decompiler")
 
@@ -21,13 +20,9 @@ class PrintHighPCode extends GhidraScript {
 
     val hfblocks = hf.getBasicBlocks.asScala
 
-    hfblocks.foreach (block => {
+    hfblocks.foreach (block =>
       println(s"Beginning of ${block.toString}")
-      block.getIterator.asScala.foreach (inst => {
+      block.getIterator.asScala.foreach (inst =>
         println(inst.toString)
-      })
-    })
-
-  }
-}
-
+      )
+    )

--- a/src/main/java/scalascriptprovider/ScalaScriptProvider.java
+++ b/src/main/java/scalascriptprovider/ScalaScriptProvider.java
@@ -26,10 +26,7 @@ import java.net.URL;
 import java.net.MalformedURLException;
 import java.net.URLClassLoader;
 
-import scala.collection.JavaConversions;
-import scala.tools.nsc.MainClass;
-import scala.tools.nsc.Settings;
-import scala.tools.nsc.CompilerCommand;
+import scala.jdk.CollectionConverters;
 
 import javax.tools.*;
 import javax.tools.JavaCompiler.CompilationTask;
@@ -102,6 +99,7 @@ public class ScalaScriptProvider extends GhidraScriptProvider {
 				"Error during class initialization: " + e.getException(), e.getException());
 		}
 		catch (Exception e) {
+			e.printStackTrace();
 			throw new GhidraScriptLoadException("Unexpected error: " + e);
 		}
 


### PR DESCRIPTION
Based on the conversation in [issue 34](https://github.com/edmcman/ghidra-scala-loader/issues/34) I tweaked the code to support Scala 3.3.4. However, maybe it would be nicer to have the two versions side-by-side?

The scripts that come in `ghidra_scripts` work fine. However, I copied the `HelloWorldScript.scala` in my own custom ghidra scripts, and it does not work. I will try to debug more in the next few days but this is the output of Ghidra.

![image](https://github.com/user-attachments/assets/264d6e1b-e09d-4524-aed5-da082a13ce50)

As you can see in the screenshot, `HelloWorldScript.scala` works fine but `HelloWorldCopiedScript.scala` is succesfully compiled but cannot be loaded.