### PR TITLE
Remove old Scala 2 compiler option

### DIFF
--- a/src/main/scala/scalascriptprovider/ScalaHelper.scala
+++ b/src/main/scala/scalascriptprovider/ScalaHelper.scala
@@ -11,7 +11,6 @@ import java.util.function.Consumer
 class ScalaHelper:
     def compile(errorFn: Consumer[java.lang.String], outputDirectory: String, sourcePath: String, classPath: String, sourceFileName: String): Boolean =
         val args = Array(
-            "-g:source",
             "-d", outputDirectory,
             "-sourcepath", sourcePath,
             "-classpath", classPath,


### PR DESCRIPTION
An old compiler option was still being used in the project: `-g:source`.

As stated in the [migration guide](https://docs.scala-lang.org/scala3/guides/migration/options-intro.html), this options are just ignored and generate a warning so this update does not change anything functionally.

## Summary by Sourcery

Enhancements:
- Remove an obsolete compiler option that was generating warnings during compilation