### PR TITLE
Upgrade pip to enable ghidra master builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,6 +142,7 @@ jobs:
   - bash: |
       set -ex
       cd ghidra
+      pip install --upgrade pip
       gradle --build-cache -I gradle/support/fetchDependencies.gradle
       gradle --build-cache buildGhidra
       mkdir -p $WS/zip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,7 +142,7 @@ jobs:
   - bash: |
       set -ex
       cd ghidra
-      pip install --upgrade pip
+      python -m pip install --upgrade pip
       gradle --build-cache -I gradle/support/fetchDependencies.gradle
       gradle --build-cache buildGhidra
       mkdir -p $WS/zip


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a 'pip install --upgrade pip' step to the Ghidra build job in azure-pipelines.yml