### PR TITLE
Update Ghidra version to 11.4 in Azure Pipelines configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ schedules:
 # I wish there was a better way of doing this but shields.io removed their
 # filter support for json path queries
 variables:
-  latest_ghidra: '11.3.2'
+  latest_ghidra: '11.4'
 
 jobs:
 - job: Build_Ghidra_Plugin
@@ -75,6 +75,10 @@ jobs:
       ghidra1132:
         ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_11.3.2_build/ghidra_11.3.2_PUBLIC_20250415.zip"
         ghidraVersion: "11.3.2"
+        useJava21: true
+      ghidra114:
+        ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_11.4_build/ghidra_11.4_PUBLIC_20250620.zip"
+        ghidraVersion: "11.4"
         useJava21: true
   pool:
     vmImage: 'Ubuntu-22.04'


### PR DESCRIPTION
## Summary by Sourcery

Update Azure Pipelines to use Ghidra 11.4

CI:
- Bump latest_ghidra variable to 11.4
- Add ghidra114 job configuration with the new download URL and version