### PR TITLE
Add Ghidra 12 configuration to pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,10 @@ jobs:
         ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_11.4.2_build/ghidra_11.4.2_PUBLIC_20250826.zip"
         ghidraVersion: "11.4.2"
         useJava21: true
+      ghidra12:
+        ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.0_build/ghidra_12.0_PUBLIC_20251205.zip"
+        ghidraVersion: "12.0"
+        useJava21: true
   pool:
     vmImage: 'Ubuntu-22.04'
   steps:


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Configure an additional pipeline target for Ghidra 12.0 using Java 21 with its corresponding download URL and version metadata.