### PR TITLE
Add Ghidra 12.0.2 to pipeline and bump latest_ghidra

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ schedules:
 # I wish there was a better way of doing this but shields.io removed their
 # filter support for json path queries
 variables:
-  latest_ghidra: '12.0.1'
+  latest_ghidra: '12.0.2'
 
 jobs:
 - job: Build_Ghidra_Plugin
@@ -95,6 +95,10 @@ jobs:
       ghidra1201:
         ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.0.1_build/ghidra_12.0.1_PUBLIC_20260114.zip"
         ghidraVersion: "12.0.1"
+        useJava21: true
+      ghidra1202:
+        ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.0.2_build/ghidra_12.0.2_PUBLIC_20260129.zip"
+        ghidraVersion: "12.0.2"
         useJava21: true
   pool:
     vmImage: 'Ubuntu-22.04'


### PR DESCRIPTION
## Summary by Sourcery

Add support for Ghidra 12.0.2 in the build pipeline and update the tracked latest Ghidra version.

Build:
- Update the latest_ghidra pipeline variable from 12.0.1 to 12.0.2.
- Extend the Ghidra plugin build matrix to include a configuration for Ghidra 12.0.2 using Java 21.