### PR TITLE
Ghidra 12.0.4 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ schedules:
 # I wish there was a better way of doing this but shields.io removed their
 # filter support for json path queries
 variables:
-  latest_ghidra: '12.0.3'
+  latest_ghidra: '12.0.4'
 
 jobs:
 - job: Build_Ghidra_Plugin
@@ -103,6 +103,10 @@ jobs:
       ghidra1203:
         ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.0.3_build/ghidra_12.0.3_PUBLIC_20260210.zip"
         ghidraVersion: "12.0.3"
+        useJava21: true
+      ghidra1204:
+        ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.0.4_build/ghidra_12.0.4_PUBLIC_20260303.zip"
+        ghidraVersion: "12.0.4"
         useJava21: true
   pool:
     vmImage: 'Ubuntu-22.04'


### PR DESCRIPTION
## Summary by Sourcery

Update CI configuration to target Ghidra 12.0.4 as the latest supported version.

Build:
- Bump latest_ghidra variable to 12.0.4 in Azure Pipelines configuration.
- Add a new Ghidra 12.0.4 build configuration with corresponding download URL and Java 21 settings.