### PR TITLE
Ghidra 12.1 support

### DIFF
--- a/.claude/skills/update-ghidra.md
+++ b/.claude/skills/update-ghidra.md
@@ -1,0 +1,75 @@
+---
+description: Update the project for a new Ghidra version
+argument-hint: <version>
+allowed-tools: [Read, Edit, Write, Bash, WebSearch, WebFetch, Agent]
+---
+
+# Update Ghidra to $ARGUMENTS
+
+Update this project to support Ghidra version $ARGUMENTS.
+
+## Step 1: Look up the Ghidra release
+
+Use `gh api` to find the release details for Ghidra $ARGUMENTS:
+
+```
+gh api repos/NationalSecurityAgency/ghidra/releases/tags/Ghidra_$ARGUMENTS_build
+```
+
+Extract from the response:
+- The exact ZIP filename (matches `ghidra_*_PUBLIC_*.zip`)
+- The download URL (or construct it: `https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_$ARGUMENTS_build/<filename>`)
+- The release date (needed for the devcontainer)
+
+If the tag lookup fails, try a web search for "Ghidra $ARGUMENTS release" on github.com/NationalSecurityAgency/ghidra/releases.
+
+## Step 2: Update `azure-pipelines.yml`
+
+1. Change the `latest_ghidra` variable from the current version to `$ARGUMENTS`
+2. Add a new matrix entry after the last existing ghidra entry. Follow this pattern (use the correct version, URL, and filename from step 1):
+
+```yaml
+      ghidra<key>:
+        ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_<version>_build/<filename>.zip"
+        ghidraVersion: "<version>"
+        useJava21: true
+```
+
+The key is the version with dots removed (e.g., `12.1` → `ghidra121`).
+
+## Step 3: Update `.github/workflows/test.yml`
+
+Change the `GHIDRA_VERSION` env var to `"$ARGUMENTS"`.
+
+## Step 4: Update `.devcontainer/devcontainer.json`
+
+1. If the Ghidra version requires Java 21 (all 11.2+), update the image to `mcr.microsoft.com/devcontainers/java:1-21`. Otherwise use `java:0-17`.
+2. Update the `postCreateCommand` with the new download URL and ZIP filename
+3. Update `GHIDRA_INSTALL_DIR` to use the new Ghidra directory name (e.g., `ghidra_12.1_PUBLIC`)
+
+The Ghidra directory name comes from the ZIP: `ghidra_12.1_PUBLIC_20260513.zip` extracts to `ghidra_12.1_PUBLIC/`.
+
+## Step 5: Build and test
+
+1. Check if the new Ghidra version is already installed locally:
+   ```
+   ls ~/Ghidra/ | grep $ARGUMENTS
+   ```
+2. If not installed, download it:
+   ```
+   cd ~/Ghidra && wget <url> && unzip <filename>
+   ```
+3. Build the extension against the new Ghidra:
+   ```
+   GHIDRA_INSTALL_DIR=~/Ghidra/ghidra_<version>_PUBLIC ./gradlew clean build
+   ```
+4. Install and test with analyzeHeadless:
+   ```
+   GHIDRA_INSTALL_DIR=~/Ghidra/ghidra_<version>_PUBLIC ./gradlew install
+   mkdir -p /tmp/ghidra_test && ~/Ghidra/ghidra_<version>_PUBLIC/support/analyzeHeadless /tmp/ghidra_test TestProject -import /bin/ls -noanalysis -postScript HelloWorldScript.scala -deleteProject 2>&1 | tee /tmp/ghidra_test/output.log
+   grep -q "Hello world, I'm written in Scala 3!" /tmp/ghidra_test/output.log
+   ```
+
+## Step 6: Report
+
+Summarize what was changed and whether the build/test passed. If there are source code compatibility issues with the new Ghidra version, report them.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Java",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/java:0-17",
+	"image": "mcr.microsoft.com/devcontainers/java:1-21",
 
 	"features": {
 		"ghcr.io/devcontainers/features/java:1": {
@@ -17,10 +17,10 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "test -f ghidra_10.4_PUBLIC_20230928.zip || (wget https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.4_build/ghidra_10.4_PUBLIC_20230928.zip && unzip ghidra_10.4_PUBLIC_20230928.zip)",
+	"postCreateCommand": "test -f ghidra_12.1_PUBLIC_20260513.zip || (wget https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1_build/ghidra_12.1_PUBLIC_20260513.zip && unzip ghidra_12.1_PUBLIC_20260513.zip)",
 
 	"remoteEnv": {
-		"GHIDRA_INSTALL_DIR": "/workspaces/ghidra-scala-loader/ghidra_10.4_PUBLIC"
+		"GHIDRA_INSTALL_DIR": "/workspaces/ghidra-scala-loader/ghidra_12.1_PUBLIC"
 	},
 	"customizations": {
 		"vscode": {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  GHIDRA_VERSION: "12.0.4"
+  GHIDRA_VERSION: "12.1"
 
 jobs:
   test:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ schedules:
 # I wish there was a better way of doing this but shields.io removed their
 # filter support for json path queries
 variables:
-  latest_ghidra: '12.0.4'
+  latest_ghidra: '12.1'
 
 jobs:
 - job: Build_Ghidra_Plugin
@@ -107,6 +107,10 @@ jobs:
       ghidra1204:
         ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.0.4_build/ghidra_12.0.4_PUBLIC_20260303.zip"
         ghidraVersion: "12.0.4"
+        useJava21: true
+      ghidra121:
+        ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1_build/ghidra_12.1_PUBLIC_20260513.zip"
+        ghidraVersion: "12.1"
         useJava21: true
   pool:
     vmImage: 'Ubuntu-22.04'


### PR DESCRIPTION
## Summary
- Add Ghidra 12.1 to the CI build matrix and update the latest supported version from 12.0.4 to 12.1
- Update devcontainer from Ghidra 10.4 / Java 17 to Ghidra 12.1 / Java 21
- Update GitHub Actions test workflow to test against Ghidra 12.1

No source code changes needed — the Ghidra script provider APIs are stable across 12.0.4 → 12.1.

## Test plan
- [x] Built extension against Ghidra 12.1 — compiles successfully
- [x] Installed and ran HelloWorldScript.scala via analyzeHeadless with Ghidra 12.1 — outputs "Hello world, I'm written in Scala 3!"
- [ ] CI builds pass across all supported Ghidra versions

## Summary by Sourcery

Add support for Ghidra 12.1 across CI pipelines, GitHub Actions tests, and development container configuration.

Build:
- Update Azure Pipelines configuration to treat Ghidra 12.1 as the latest supported version and include it in the build matrix.
- Update devcontainer configuration to use the Ghidra 12.1 toolchain and corresponding Java version.

CI:
- Update GitHub Actions test workflow to run tests against Ghidra 12.1.