### PR TITLE
Ghidra 12.1.2 support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,10 +17,10 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "test -f ghidra_12.1_PUBLIC_20260513.zip || (wget https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1_build/ghidra_12.1_PUBLIC_20260513.zip && unzip ghidra_12.1_PUBLIC_20260513.zip)",
+	"postCreateCommand": "test -f ghidra_12.1.2_PUBLIC_20260605.zip || (wget https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1.2_build/ghidra_12.1.2_PUBLIC_20260605.zip && unzip ghidra_12.1.2_PUBLIC_20260605.zip)",
 
 	"remoteEnv": {
-		"GHIDRA_INSTALL_DIR": "/workspaces/ghidra-scala-loader/ghidra_12.1_PUBLIC"
+		"GHIDRA_INSTALL_DIR": "/workspaces/ghidra-scala-loader/ghidra_12.1.2_PUBLIC"
 	},
 	"customizations": {
 		"vscode": {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  GHIDRA_VERSION: "12.1"
+  GHIDRA_VERSION: "12.1.2"
 
 jobs:
   test:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ schedules:
 # I wish there was a better way of doing this but shields.io removed their
 # filter support for json path queries
 variables:
-  latest_ghidra: '12.1'
+  latest_ghidra: '12.1.2'
 
 jobs:
 - job: Build_Ghidra_Plugin
@@ -111,6 +111,10 @@ jobs:
       ghidra121:
         ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1_build/ghidra_12.1_PUBLIC_20260513.zip"
         ghidraVersion: "12.1"
+        useJava21: true
+      ghidra1212:
+        ghidraUrl: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1.2_build/ghidra_12.1.2_PUBLIC_20260605.zip"
+        ghidraVersion: "12.1.2"
         useJava21: true
   pool:
     vmImage: 'Ubuntu-22.04'


### PR DESCRIPTION
## Summary
- Adds `ghidra1212` matrix entry to `azure-pipelines.yml` targeting the 12.1.2 release
- Updates `latest_ghidra` variable to `12.1.2`
- Bumps `GHIDRA_VERSION` in `.github/workflows/test.yml` to `12.1.2`
- Updates `.devcontainer/devcontainer.json` download URL and `GHIDRA_INSTALL_DIR` to `ghidra_12.1.2_PUBLIC`

## Test plan
- [x] Built extension against `ghidra_12.1.2_PUBLIC` locally — `BUILD SUCCESSFUL`
- [x] Ran `HelloWorldScript.scala` via `analyzeHeadless` — output confirmed `Hello world, I'm written in Scala 3!`

## Summary by Sourcery

Add support for building, testing, and developing against Ghidra 12.1.2.

Enhancements:
- Update devcontainer configuration to download and use the Ghidra 12.1.2 public release.

Build:
- Update Azure Pipelines configuration to treat Ghidra 12.1.2 as the latest supported version and add a dedicated 12.1.2 build matrix entry.

CI:
- Bump GHIDRA_VERSION in the GitHub Actions test workflow to 12.1.2.